### PR TITLE
Fix js-yaml quadratic-complexity DoS vulnerability (GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4088,9 +4088,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Transitive dep via ts-jest -> @jest/transform -> babel-plugin-istanbul; bump js-yaml 3.14.2 -> 3.15.0.

Not bumping version or releasing - this is a test library dependency.